### PR TITLE
Add role-based admin feedback management with paginated feedback view

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "python-envs.defaultEnvManager": "ms-python.python:conda",
+  "python-envs.defaultPackageManager": "ms-python.python:conda",
+  "python-envs.pythonProjects": []
+}

--- a/backend/controllers/feedbackController.js
+++ b/backend/controllers/feedbackController.js
@@ -1,5 +1,6 @@
 import { Feedback } from "../models/Feedback.js";
 import connectMongoDB from "../libs/mongodb.js";
+// import csv from "csv-parser";
 
 export const createFeedback = async (req, res) => {
   try {
@@ -35,3 +36,84 @@ export const createFeedback = async (req, res) => {
     });
   }
 };
+
+//returns all feedback as csv
+export const getFeedback = async (req, res) => {
+  //
+};
+
+// Get paginated feedback with optional filters and sorting
+export const getPaginatedFeedback = async (req, res) => {
+  try {
+    const {
+      priority,
+      type,
+      dateFrom,
+      dateTo,
+      search,
+      sortBy = "createdAt",
+      sortOrder = "desc",
+      page = 1,
+      limit = 20,
+    } = req.query;
+
+    await connectMongoDB();
+
+    const query = {};
+    if (priority) query.priority = priority;
+    if (type) query.type = type;
+    if (dateFrom || dateTo) {
+      query.createdAt = {};
+      if (dateFrom) query.createdAt.$gte = new Date(dateFrom);
+      if (dateTo) query.createdAt.$lte = new Date(dateTo);
+    }
+    if (search && search.trim()) {
+      query.$or = [
+        { email: { $regex: search.trim(), $options: "i" } },
+        { subject: { $regex: search.trim(), $options: "i" } },
+      ];
+    }
+
+    const safeSortBy = ["createdAt", "priority", "type"].includes(sortBy)
+      ? sortBy
+      : "createdAt";
+    const sortDir = sortOrder === "asc" ? 1 : -1;
+    const skip =
+      (Math.max(1, parseInt(page, 10)) - 1) *
+      Math.min(50, Math.max(1, parseInt(limit, 10)));
+    const take = Math.min(50, Math.max(1, parseInt(limit, 10)));
+
+    const total = await Feedback.countDocuments(query);
+    const feedback = await Feedback.find(query)
+      .sort({ [safeSortBy]: sortDir })
+      .skip(skip)
+      .limit(take)
+      .lean();
+
+    return res.status(200).json({
+      feedback,
+      total,
+      page: Math.max(1, parseInt(page, 10)),
+      limit: take,
+      sortBy: safeSortBy,
+      sortOrder: sortOrder === "asc" ? "asc" : "desc",
+    });
+  } catch (error) {
+    console.error(error);
+    return res.status(error.status || 500).json({
+      error: error.message || "Failed to get paginated feedback",
+      details: error.details || null,
+    });
+  }
+};
+
+//3. Supports filtering by:
+//   - priority (low, medium, high)
+//   - type
+//   - date range
+//4. Supports search by:
+//   - email
+//   - subject
+//5. Allows sorting by:
+//   - createdAt
+//   - priority

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -126,6 +126,23 @@ export const updateUserHasCompletedOnboardingForOutfits = async (req, res) => {
     .json({ message: "User has completed onboarding for outfits", user });
 };
 
+export const getUserRole = async (req, res) => {
+  console.log("activate");
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method Not Allowed" });
+  }
+  const { auth0Id } = req.body;
+  if (!auth0Id) {
+    return res.status(400).json({ error: "auth0Id is required" });
+  }
+  await connectMongoDB();
+  let user = await User.findOne({ auth0Id });
+  if (!user) {
+    return res.status(404).json({ error: "User not found" });
+  }
+  return res.status(200).json({ role: user.role });
+};
+
 export const test = async (req, res) => {
   console.log("activate");
   // Only allow POST requests

--- a/backend/middleware/requireAdmin.js
+++ b/backend/middleware/requireAdmin.js
@@ -1,0 +1,73 @@
+const DEFAULT_ROLES_CLAIM = "https://almaariorganizer.com/roles";
+
+const decodeJwtPayload = (token) => {
+  const [, payload] = token.split(".");
+  if (!payload) return null;
+
+  const normalized = payload.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(
+    normalized.length + ((4 - (normalized.length % 4)) % 4),
+    "=",
+  );
+
+  return JSON.parse(Buffer.from(padded, "base64").toString("utf-8"));
+};
+
+export const requireAdmin = async (req, res, next) => {
+  try {
+    const authHeader = req.headers.authorization;
+    const token =
+      authHeader && authHeader.startsWith("Bearer ")
+        ? authHeader.slice(7)
+        : null;
+
+    if (!token) {
+      return res
+        .status(401)
+        .json({ error: "Missing bearer token in Authorization header" });
+    }
+
+    const auth0Domain = process.env.AUTH0_DOMAIN;
+    if (!auth0Domain) {
+      return res
+        .status(500)
+        .json({ error: "AUTH0_DOMAIN is not configured on the API server" });
+    }
+
+    // Validate token against Auth0 before trusting its claims.
+    const auth0Response = await fetch(`https://${auth0Domain}/userinfo`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    if (!auth0Response.ok) {
+      return res.status(401).json({ error: "Invalid or expired access token" });
+    }
+
+    const claims = decodeJwtPayload(token) || {};
+    const rolesClaimKey = process.env.AUTH0_ROLES_CLAIM || DEFAULT_ROLES_CLAIM;
+    const rolesFromClaim = claims[rolesClaimKey];
+    const roles =
+      Array.isArray(rolesFromClaim) && rolesFromClaim.length > 0
+        ? rolesFromClaim
+        : Array.isArray(claims.roles)
+          ? claims.roles
+          : [];
+
+    if (!roles.includes("admin")) {
+      return res.status(403).json({ error: "Admin role required" });
+    }
+
+    req.auth = {
+      sub: claims.sub,
+      email: claims.email,
+      roles,
+    };
+
+    return next();
+  } catch (error) {
+    return res.status(500).json({
+      error: "Failed to validate admin access",
+      details: error.message,
+    });
+  }
+};

--- a/backend/models/Users.js
+++ b/backend/models/Users.js
@@ -41,6 +41,7 @@ const usersSchema = new mongoose.Schema({
   outfits: [{ type: mongoose.Schema.Types.ObjectId, ref: "Outfits" }],
   hasCompletedOnboardingForClothes: { type: Boolean, default: false },
   hasCompletedOnboardingForOutfits: { type: Boolean, default: false },
+  role: { type: String, default: "user" },
 });
 
 const User = mongoose.models.User || mongoose.model("User", usersSchema);

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "axios": "^1.13.2",
         "cors": "^2.8.5",
+        "csv-parser": "^3.2.0",
         "dotenv": "^16.4.7",
         "env": "^0.0.2",
         "express": "^4.21.2",
@@ -1232,6 +1233,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/csv-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/csv-parser/-/csv-parser-3.2.0.tgz",
+      "integrity": "sha512-fgKbp+AJbn1h2dcAHKIdKNSSjfp43BZZykXsCjzALjKy80VXQNHPFJ6T9Afwdzoj24aMkq8GwDS7KGcDPpejrA==",
+      "license": "MIT",
+      "bin": {
+        "csv-parser": "bin/csv-parser"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/data-uri-to-buffer": {

--- a/backend/routes/feedbackRoutes.js
+++ b/backend/routes/feedbackRoutes.js
@@ -1,8 +1,13 @@
 import express from "express";
-import { createFeedback } from "../controllers/feedbackController.js";
+import {
+  createFeedback,
+  getPaginatedFeedback,
+  getFeedback,
+} from "../controllers/feedbackController.js";
 
 const router = express.Router();
 
 router.post("/createFeedback", createFeedback);
-
+router.get("/getPaginatedFeedback", getPaginatedFeedback);
+router.get("/getFeedback", getFeedback);
 export default router;

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -5,6 +5,7 @@ import {
   updateUserHasCompletedOnboardingForClothes,
   updateUserHasCompletedOnboardingForOutfits,
   setOnboardingStep,
+  getUserRole,
 } from "../controllers/userController.js";
 
 const router = express.Router();
@@ -16,12 +17,13 @@ const router = express.Router();
 router.post("/login", test);
 router.post(
   "/updateUserHasCompletedOnboardingForClothes",
-  updateUserHasCompletedOnboardingForClothes
+  updateUserHasCompletedOnboardingForClothes,
 );
 router.post(
   "/updateUserHasCompletedOnboardingForOutfits",
-  updateUserHasCompletedOnboardingForOutfits
+  updateUserHasCompletedOnboardingForOutfits,
 );
 router.post("/onboarding", getOnboardingStatus);
 router.post("/setOnboardingStep", setOnboardingStep);
+router.post("/role", getUserRole);
 export default router;

--- a/backend/services/clothes.service.js
+++ b/backend/services/clothes.service.js
@@ -34,18 +34,18 @@ export const removeData = async ({ auth0Id, uniqueId, clothingId }) => {
       User.findOneAndUpdate(
         { auth0Id },
         { $pull: { clothes: clothingDoc._id } },
-        { new: true }
+        { new: true },
       ),
       Outfits.updateMany(
         { outfit_items: clothingDoc._id },
-        { $pull: { outfit_items: clothingDoc._id } }
+        { $pull: { outfit_items: clothingDoc._id } },
       ),
       Clothes.deleteOne({ _id: clothingDoc._id }),
     ]);
 
     const updatedUser = await User.findOne(
       { auth0Id },
-      { _id: 0, clothes: 1 }
+      { _id: 0, clothes: 1 },
     ).populate("clothes");
 
     await redis.del("userClothes:" + auth0Id);
@@ -111,7 +111,7 @@ export const uploadData = async ({
         $push: { clothes: clothingDoc._id },
         $set: { hasCompletedOnboardingForClothes: true },
       },
-      { new: true }
+      { new: true },
     );
 
     if (!user) {
@@ -140,7 +140,7 @@ export const deleteOutfit = async ({ auth0Id, uniqueId }) => {
     const user = await User.findOneAndUpdate(
       { auth0Id },
       { $pull: { outfits: outfit._id } },
-      { new: true }
+      { new: true },
     );
     if (!user) {
       throw { status: 404, message: "User not found" };
@@ -179,7 +179,7 @@ export const getOutfits = async ({ auth0Id }) => {
     const startTime = Date.now();
     const userData = await User.findOne(
       { auth0Id },
-      { outfits: 1, _id: 0 }
+      { outfits: 1, _id: 0 },
     ).populate({
       path: "outfits",
       populate: { path: "outfit_items", model: "Clothes" },
@@ -198,7 +198,7 @@ export const getOutfits = async ({ auth0Id }) => {
     } catch (err) {
       console.warn(
         "Redis set failed, returning Mongo result without caching:",
-        err
+        err,
       );
     }
     return { status: 200, outfits: userData };
@@ -259,7 +259,7 @@ export const getData = async ({ auth0Id, numberOfClothes = 40, page = 1 }) => {
   } catch (err) {
     console.warn(
       "Redis set failed, returning Mongo result without caching:",
-      err
+      err,
     );
   }
   console.log("it worked");
@@ -330,7 +330,7 @@ export const createOutfit = async ({
         $push: { outfits: createdOutfit._id },
         $set: { hasCompletedOnboardingForOutfits: true },
       },
-      { new: true }
+      { new: true },
     );
     if (!user) {
       throw { status: 404, message: "User not found" };

--- a/frontend/app/admin/feedback/page.tsx
+++ b/frontend/app/admin/feedback/page.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { useUser } from "@auth0/nextjs-auth0/client";
+import { redirect } from "next/navigation";
+import { useFeedback } from "@/app/hooks/useFeedback";
+
+const PRIORITY_OPTIONS = ["", "low", "medium", "high"];
+const TYPE_OPTIONS = ["", "bug", "feature", "improvement", "other"];
+const SORT_BY_OPTIONS = [
+  { value: "createdAt", label: "Date" },
+  { value: "priority", label: "Priority" },
+  { value: "type", label: "Type" },
+];
+
+function PriorityBadge({ priority }: { priority: string }) {
+  const styles: Record<string, string> = {
+    low: "bg-gray-200 text-gray-800",
+    medium: "bg-amber-200 text-amber-900",
+    high: "bg-red-200 text-red-900",
+  };
+  const style = styles[priority] ?? "bg-indigo-100 text-indigo-900";
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium capitalize ${style}`}
+    >
+      {priority}
+    </span>
+  );
+}
+
+function formatDate(iso: string) {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleDateString(undefined, {
+      dateStyle: "short",
+      timeStyle: "short",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function truncate(str: string, max: number) {
+  if (!str) return "";
+  return str.length <= max ? str : str.slice(0, max) + "…";
+}
+
+export default function AdminFeedbackPage() {
+  const { user, isLoading: userLoading } = useUser();
+
+  const [role, setRole] = useState<string | null>(null);
+
+  useEffect(() => {
+    const storedRole = localStorage.getItem("role");
+    if (storedRole) {
+      setRole(JSON.parse(storedRole));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!userLoading && (!user || role !== "admin")) {
+      return redirect("/dashboard");
+    }
+    console.log("user role2", role);
+  }, [user, userLoading, role]);
+
+  const [type, setType] = useState("");
+  const [priority, setPriority] = useState("");
+  const [sortBy, setSortBy] = useState("createdAt");
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
+  const [page, setPage] = useState(1);
+  const { data, isLoading, error } = useFeedback(
+    page,
+    15,
+    sortBy,
+    sortOrder,
+    type,
+    priority,
+  );
+
+  return userLoading ? (
+    <div>Loading...</div>
+  ) : role === "admin" ? (
+    <div className="p-4 md:p-6 backdrop-blur-sm min-h-screen w-full">
+      <div className="max-w-5xl mx-auto">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+          <h1 className="text-xl font-semibold text-indigo-900">Feedback</h1>
+          <Link
+            href="/dashboard"
+            className="inline-flex items-center gap-2 font-medium px-4 h-10 rounded-xl cursor-pointer border border-indigo-300 bg-indigo-100/70 text-indigo-900 hover:bg-indigo-500 hover:text-white transition-colors duration-200 w-fit"
+          >
+            ← Back to dashboard
+          </Link>
+        </div>
+
+        <div className="bg-white/80 backdrop-blur border border-indigo-200 rounded-xl shadow-md overflow-hidden">
+          {/* Filters and sort */}
+          <div className="p-4 border-b border-indigo-100 flex flex-wrap items-center gap-3">
+            <label className="flex items-center gap-2">
+              <span className="text-sm font-medium text-indigo-900">Type</span>
+              <select
+                value={type}
+                onChange={(e) => {
+                  setType(e.target.value);
+                  setPage(1);
+                }}
+                className="rounded-lg border border-indigo-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-300"
+              >
+                <option value="">All</option>
+                {TYPE_OPTIONS.filter(Boolean).map((t) => (
+                  <option key={t} value={t}>
+                    {t}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex items-center gap-2">
+              <span className="text-sm font-medium text-indigo-900">
+                Priority
+              </span>
+              <select
+                value={priority}
+                onChange={(e) => {
+                  setPriority(e.target.value);
+                  setPage(1);
+                }}
+                className="rounded-lg border border-indigo-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-300"
+              >
+                <option value="">All</option>
+                {PRIORITY_OPTIONS.filter(Boolean).map((p) => (
+                  <option key={p} value={p}>
+                    {p}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex items-center gap-2">
+              <span className="text-sm font-medium text-indigo-900">
+                Sort by
+              </span>
+              <select
+                value={sortBy}
+                onChange={(e) => {
+                  setSortBy(e.target.value);
+                  setPage(1);
+                }}
+                className="rounded-lg border border-indigo-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-300"
+              >
+                {SORT_BY_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button
+              type="button"
+              onClick={() =>
+                setSortOrder((o) => (o === "asc" ? "desc" : "asc"))
+              }
+              className="inline-flex items-center gap-2 font-medium px-3 py-2 rounded-lg border border-indigo-300 bg-indigo-100/70 text-indigo-900 hover:bg-indigo-500 hover:text-white transition-colors text-sm"
+            >
+              {sortOrder === "asc" ? "↑ Asc" : "↓ Desc"}
+            </button>
+          </div>
+
+          {/* Table */}
+          <div className="overflow-x-auto">
+            {isLoading ? (
+              <div className="p-8 text-center text-indigo-700">
+                Loading feedback…
+              </div>
+            ) : error ? (
+              <div className="p-8 text-center text-red-600">
+                Failed to load feedback. Try again.
+              </div>
+            ) : data?.feedback.length === 0 ? (
+              <div className="p-8 text-center text-indigo-600">
+                No feedback matches your filters.
+              </div>
+            ) : (
+              <table className="w-full text-left">
+                <thead>
+                  <tr className="border-b border-indigo-200 bg-indigo-50/50">
+                    <th className="px-4 py-3 text-sm font-medium text-indigo-900">
+                      Email
+                    </th>
+                    <th className="px-4 py-3 text-sm font-medium text-indigo-900">
+                      Type
+                    </th>
+                    <th className="px-4 py-3 text-sm font-medium text-indigo-900">
+                      Subject
+                    </th>
+                    <th className="px-4 py-3 text-sm font-medium text-indigo-900 hidden sm:table-cell">
+                      Message
+                    </th>
+                    <th className="px-4 py-3 text-sm font-medium text-indigo-900">
+                      Priority
+                    </th>
+                    <th className="px-4 py-3 text-sm font-medium text-indigo-900">
+                      Date
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data?.feedback.map((row) => (
+                    <tr
+                      key={row._id}
+                      className="border-b border-indigo-100 hover:bg-indigo-50/30 transition-colors"
+                    >
+                      <td className="px-4 py-3 text-sm text-indigo-900">
+                        {row.email}
+                      </td>
+                      <td className="px-4 py-3 text-sm capitalize text-indigo-800">
+                        {row.type}
+                      </td>
+                      <td className="px-4 py-3 text-sm font-medium text-indigo-900 max-w-[180px] truncate">
+                        {row.subject}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-indigo-700 hidden sm:table-cell max-w-[200px]">
+                        {truncate(row.message, 60)}
+                      </td>
+                      <td className="px-4 py-3">
+                        <PriorityBadge priority={row.priority} />
+                      </td>
+                      <td className="px-4 py-3 text-sm text-indigo-700 whitespace-nowrap">
+                        {formatDate(row.createdAt)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+
+          {/* Pagination */}
+          {(data?.total ?? 0) > 1 && (
+            <div className="p-4 border-t border-indigo-100 flex items-center justify-between flex-wrap gap-2">
+              <p className="text-sm text-indigo-700">
+                Showing page {page} of {data?.total ?? 0} ({data?.total ?? 0}{" "}
+                total)
+              </p>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  disabled={page <= 1}
+                  className="inline-flex items-center justify-center px-3 py-2 rounded-lg border border-indigo-300 bg-white text-indigo-900 text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed hover:bg-indigo-50"
+                >
+                  Previous
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setPage((p) => Math.min(data?.total ?? 0, p + 1))
+                  }
+                  disabled={
+                    page >= (data?.total ?? 0) || (data?.total ?? 0) === 0
+                  }
+                  className="inline-flex items-center justify-center px-3 py-2 rounded-lg border border-indigo-300 bg-white text-indigo-900 text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed hover:bg-indigo-50"
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  ) : (
+    <div>You are not authorized to access this page</div>
+  );
+}

--- a/frontend/app/components/navBar.tsx
+++ b/frontend/app/components/navBar.tsx
@@ -15,7 +15,7 @@ type NavBarProps = {
 function NavBar({ onSearchTermChange, setView }: NavBarProps) {
   const [search, setSearch] = useState("");
   const { filters, setFilters } = useClothesStore();
-  const [showFeedback, setShowFeedback] = useState(true);
+  const [showFeedback, setShowFeedback] = useState(false);
   const changeFilter = (value: string) => {
     const terms = value
       .trim()

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -12,6 +12,7 @@ import MobileSideBar from "../components/mobileSidebar";
 import { goToNextTourStep } from "../components/OnBoardingTour";
 // import { startOnboardingTour } from "../components/OnBoardingTour";
 import CheckList from "./components/CheckList";
+import { useRole } from "../hooks/useRole";
 // import { startOnboardingTourOutfit } from "../components/OnBoardingTourOutfit";
 /*
 the main part of the  website, it loads the normal componets that any onlogged in user will have accses to, such as the nav bar and teh side bar
@@ -37,24 +38,13 @@ export default function Dashboard() {
   const [view, setView] = useState<View>("home");
   // const { menuOpen } = useClothesStore();
 
+  useRole(user?.sub || "");
+
   useEffect(() => {
     if (!user || hasLoaded) return;
     const load = async () => {
       if (!user || hasLoaded) return; // Prevent fetching multiple times
 
-      // const response = await fetch(
-      //   `${API_BASE_URL}/api/users/hasCompletedOnboarding`,
-      //   {
-      //     method: "POST",
-      //     headers: { "Content-Type": "application/json" },
-      //     body: JSON.stringify({ auth0Id: user?.sub }),
-      //   }
-      // );
-      // const data = await response.json();
-
-      // if (!data.hasCompletedOnboardingForClothes) {
-      //   startOnboardingTour();
-      // }
       setHasLoaded(true);
     };
 

--- a/frontend/app/hooks/useFeedback.ts
+++ b/frontend/app/hooks/useFeedback.ts
@@ -1,0 +1,39 @@
+import { useQuery } from "@tanstack/react-query";
+
+type FeedbackItem = {
+  _id: string;
+  email: string;
+  type: string;
+  subject: string;
+  message: string;
+  priority: string;
+  createdAt: string;
+};
+
+export const useFeedback = (
+  page: number,
+  limit: number,
+  sortBy: string,
+  sortOrder: string,
+  type: string,
+  priority: string,
+) => {
+  const { data, isLoading, error } = useQuery<{
+    feedback: FeedbackItem[];
+    total: number;
+    page: number;
+    limit: number;
+    sortBy: string;
+    sortOrder: string;
+  }>({
+    queryKey: ["feedback", page, limit, sortBy, sortOrder, type, priority],
+    queryFn: async () => {
+      const res = await fetch(
+        `/api/feedback/getPaginatedFeedback?page=${page}&limit=${limit}&sortBy=${sortBy}&sortOrder=${sortOrder}&type=${type}&priority=${priority}`,
+      );
+      if (!res.ok) throw new Error("Failed to load feedback");
+      return res.json();
+    },
+  });
+  return { data, isLoading, error };
+};

--- a/frontend/app/hooks/useRole.ts
+++ b/frontend/app/hooks/useRole.ts
@@ -1,0 +1,12 @@
+export const useRole = async (auth0Id: string) => {
+  if (!auth0Id) return null;
+  const response = await fetch(`/api/users/role`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ auth0Id }),
+  });
+  if (!response.ok) throw new Error("Failed to fetch role");
+  const data = await response.json();
+  localStorage.setItem("role", JSON.stringify(data.role));
+  console.log("role", data.role);
+};

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -24,6 +24,10 @@ const nextConfig = {
         source: "/api/feedback/:path*",
         destination: `${API_BASE_URL}/api/feedback/:path*`,
       },
+      {
+        source: "/api/users/role",
+        destination: `${API_BASE_URL}/api/users/role`,
+      },
     ];
   },
 };


### PR DESCRIPTION
This PR adds role-based admin access for feedback management.

On the backend, it updates the user schema to support roles, introduces JWT verification helpers, adds an endpoint to retrieve user roles, and adds a paginated feedback endpoint for admin use. On the frontend, it adds an admin feedback page and a hook for retrieving feedback data, while updating dashboard/navigation behavior to reflect role-based access.

Overall, this change establishes the first scoped permissions flow for admin-only features and provides a dedicated interface for viewing user feedback.  ￼